### PR TITLE
Closes #4 - Adding the ability to deploy per-server plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,23 @@
 Nagios NRPE Server Config
 =========
 
-A Ansible role to handle the installation and rollout of the Nagios NRPE Daemon.
+[![Build Status](https://travis-ci.org/Mooash/nagios-nrpe-server.svg?branch=master)](https://travis-ci.org/Mooash/nagios-nrpe-server)
 
-I've only selected certain platforms that I know this 100% works on, but it will work on any platform that NRPE can be installed on.
+An Ansible role to handle the installation and rollout of the Nagios NRPE Daemon.
+
+I've only selected certain platforms that I know this 100% works on, but it should work on any platform that NRPE can be installed on.
 
 Requirements
 ------------
 
 RedHat based OS's must have the EPEL repo.
+
+Role Information
+--------------
+
+This role gives you the ability to deploy plugins on a global and per-server basis. This can be done by putting plugins into [`files/plugins/global`](files/plugins/global) or by creating a folder in `files/plugins/` that is the servers [FQDN](http://en.wikipedia.org/wiki/Fully_qualified_domain_name).
+
+You can find out your servers FQDN by running the [Ansible Setup](http://docs.ansible.com/setup_module.html) module.
 
 Role Variables
 --------------

--- a/files/plugins/README.md
+++ b/files/plugins/README.md
@@ -1,0 +1,3 @@
+Place plugin files here so that they're deployed by Ansible.
+
+Files in the `files/plugins/global/` folder will be deployed to all systems, files in `files/plugins/{{ ansible_fqdn }}/` will only be deployed to the server that has that FQDN.

--- a/files/plugins/global/README.md
+++ b/files/plugins/global/README.md
@@ -1,0 +1,1 @@
+This is just a placeholder so that git doesn't ignore this folder

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -46,14 +46,24 @@
   notify: restart nagios-nrpe-server
 
 # Sync our plugins
-- name: Install plugins
+- name: Install global plugins
   sudo: true
   copy: >
     src="{{ item }}"
     dest="{{ nagios_nrpe_server_plugins_dir }}/"
     owner=root group=root mode=0755
   with_fileglob:
-    - plugins/*
+    - plugins/global/*
+
+# Install per-server plugins
+- name: Install per-server plugins
+  sudo: true
+  copy: >
+    src="{{ item }}"
+    dest="{{ nagios_nrpe_server_plugins_dir }}/"
+    owner=root group=root mode=0755
+  with_fileglob:
+    - "plugins/{{ ansible_fqdn }}/*"
 
 # Ensure NRPE server is running and will start at boot
 - name: Ensure NRPE server is running


### PR DESCRIPTION
This extends the funcionality that I originally implemented for plugin deployment by adding a global folder and a per-server folder that is dependent on their FQDN