### PR TITLE
Fix idempotence in Debian by moving update_cache

### DIFF
--- a/tasks/packages-Debian.yml
+++ b/tasks/packages-Debian.yml
@@ -1,12 +1,8 @@
 ---
-# Update apt-cache for Debian based OS's
-- name: Update apt cache [Debian]
-  apt:
-    update_cache: yes
-
 # Nagios NRPE Server for Debian based OS's
 - name: Install Nagios NRPE Server [Debian]
   apt:
+    update_cache: yes
     name: nagios-nrpe-server
     state: present
 


### PR DESCRIPTION
This makes the role idempotent on Debian platforms.
When called in a separate task the "update_cache" option always return "changed".
When combined with a package to be installed, it returns changed only if the package isn't already installed.
It **still always updates apt cache**, so the following apt instructions will continue to benefit from a fresh cache.
