### PR TITLE
Fix deprecated module include

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,7 +6,7 @@
   include_tasks: "variables.yml"
 
 # Install our needed packages for each specific OS
-- include: "packages-{{ ansible_os_family }}.yml"
+- include_tasks: "packages-{{ ansible_os_family }}.yml"
 
 # Create our config
 - name: Create nrpe.cfg from template


### PR DESCRIPTION
`Include` is going to be deprecated and should be replaced by either `include_tasks` or `import_tasks`