### PR TITLE
Fix deprecation warnings for ansible-core 2.24

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,7 +1,7 @@
 ---
 # Restart the Nagios NRPE Server
 # Since RedHat based OS's and Debian based ones call the service
-# different names, we use a variable set in vars/{{ ansible_os_family }}.yml
+# different names, we use a variable set in vars/{{ ansible_facts["os_family"] }}.yml
 
 - name: restart nagios-nrpe-server
   service:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,7 +6,7 @@
   include_tasks: "variables.yml"
 
 # Install our needed packages for each specific OS
-- include: "packages-{{ ansible_os_family }}.yml"
+- include: 'packages-{{ ansible_facts["os_family"] }}.yml'
 
 # Create our config
 - name: Create nrpe.cfg from template

--- a/tasks/variables.yml
+++ b/tasks/variables.yml
@@ -1,11 +1,11 @@
 ---
 # Variable configuration.
 - name: Include OS-specific variables.
-  include_vars: "{{ ansible_os_family }}.yml"
+  include_vars: '{{ ansible_facts["os_family"] }}.yml'
 
 - name: Include OS-specific variables (RedHat).
-  include_vars: "{{ ansible_os_family }}-{{ ansible_architecture }}.yml"
-  when: ansible_os_family == 'RedHat'
+  include_vars: '{{ ansible_facts["os_family"] }}-{{ ansible_architecture }}.yml'
+  when: ansible_facts["os_family"] == 'RedHat'
 
 - name: Set defaults for OS-specific variables
   set_fact:

--- a/templates/nrpe.cfg.j2
+++ b/templates/nrpe.cfg.j2
@@ -199,7 +199,7 @@ connection_timeout=300
 #command[check_disk]={{ nagios_nrpe_server_plugins_dir }}/check_disk -w $ARG1$ -c $ARG2$ -p $ARG3$
 #command[check_procs]={{ nagios_nrpe_server_plugins_dir }}/check_procs -w $ARG1$ -c $ARG2$ -s $ARG3$
 
-{% if 'ansible_os_family' != 'Archlinux' %}
+{% if ansible_facts["os_family"] != 'Archlinux' %}
 #
 # local configuration:
 # if you'd prefer, you can instead place directives here
@@ -207,7 +207,7 @@ include={{ nagios_nrpe_server_dir }}/nrpe_local.cfg
 {% endif %}
 include={{ nagios_nrpe_server_dir }}/nrpe_ansible.cfg
 
-{% if 'ansible_os_family' != 'Archlinux' %}
+{% if ansible_facts["os_family"] != 'Archlinux' %}
 #
 # you can place your config snipplets into nrpe.d/
 # only snipplets ending in .cfg will get included


### PR DESCRIPTION
Fixes these warnings:

> TASK [jloh.nagios_nrpe_server : Include OS-specific variables.] *************************************************************************************************
> [DEPRECATION WARNING]: INJECT_FACTS_AS_VARS default to `True` is deprecated, top-level facts will not be auto injected after the change. This feature will be removed from ansible-core version 2.24.                                                                                                                             
> Origin: /home/user2/ansible/roles/jloh.nagios_nrpe_server/tasks/variables.yml:4:17                                                                              
>                                                                                                                                                                 
> 2 # Variable configuration.                                                                                                                                      
> 3 - name: Include OS-specific variables.                                                                                                                         
> 4   include_vars: "{{ ansible_os_family }}.yml"                                                                                                                  
>                  ^ column 17                                                                                                                                    
>                                                                                                                                                                
> Use `ansible_facts["fact_name"]` (no `ansible_` prefix) instead.  